### PR TITLE
Add install_vundle function to bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -138,7 +138,11 @@ install_dotfiles () {
   done
 }
 
+install_vundle() {
+  git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+}
 setup_gitconfig
+install_vundle
 install_dotfiles
 
 # If we're on a Mac, let's install and setup homebrew.


### PR DESCRIPTION
In order to properly setup a box with `.dotfiles` this commit adds the
`install_vundle` command to the `script/bootstrap`.

[154010593151898](https://app.asana.com/0/154010593151898/154010593151898)