### PR TITLE
Add satis function

### DIFF
--- a/functions/satis.functions.zsh
+++ b/functions/satis.functions.zsh
@@ -1,0 +1,11 @@
+if [ -z "$COMPOSER_HOME"]; then
+  export COMPOSER_HOME="$XDG_CONFIG_HOME/composer"
+fi
+
+function satis(){
+  docker run --rm --init -it \
+    --user $(id -u):$(id -g) \
+    --volume $(pwd):/build \
+    --volume "${COMPOSER_HOME:-$HOME/.composer}:/composer" \
+    composer/satis $1 $2 $3
+}


### PR DESCRIPTION
In order to build a private packagist site, this commit adds a satis
funciton that uses the `composer/satis` docker image to build the site.